### PR TITLE
Let db.changes() yield dict objects

### DIFF
--- a/cloudant/database.py
+++ b/cloudant/database.py
@@ -90,13 +90,15 @@ class Database(Resource):
                     kwargs['stream'] = True
                     size = 1  # 1 byte because we don't want to hold the last
                               # record in memory buffer in awaiting for new data
+        emit_heartbeats = kwargs.pop('emit_heartbeats', False)
 
         response = self.get('_changes', **kwargs)
         response.raise_for_status()
 
-        # TODO: this code duplicates index.Index.__iter__
         for line in response.iter_lines(chunk_size=size):
             if not line:
+                if emit_heartbeats:
+                    yield None
                 continue
             line = line.decode('utf-8')
             if line[-1] == ',':

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,8 +1,10 @@
 import cloudant
 from collections import defaultdict
 from types import GeneratorType
+import signal
 import time
 import unittest
+
 
 
 class ResourceTest(unittest.TestCase):
@@ -192,6 +194,30 @@ class DatabaseTest(ResourceTest):
         _next()
         assert time.time() - start < 2, \
             'should return changes event for both documents before block'
+
+    def testChangesFeedEmitsHeartbeats(self):
+        def signal_handler(signum, frame):
+            raise Exception("Timed out!")
+
+        def loop():
+            feed = self.db.changes(params={
+                'feed': 'continuous',
+                'timeout': 2000,
+                'heartbeat': 1000
+            }, emit_heartbeats=True)
+            for item in feed:
+                stack.append(item)
+
+        stack = []
+        self.db.bulk_docs(self.test_doc, self.test_otherdoc)
+
+        signal.signal(signal.SIGALRM, signal_handler)
+        signal.alarm(3)
+
+        try:
+            loop()
+        except Exception:
+            assert stack[-1] is None
 
     def testViewCleanup(self):
         assert self.db.view_cleanup().status_code == 202


### PR DESCRIPTION
This change allows to process changes feed events without any additional
magic work as iter_lines, parsing json, handling heartbeats - all these
routines are wrapped inside changes() method.

Also, for continuous changes feed it doesn't holds anymore the latest
change events in memory till request timeout or new change events.
