### PR TITLE
Move session, login and logout methods from Resource to Account

### DIFF
--- a/cloudant/account.py
+++ b/cloudant/account.py
@@ -56,6 +56,24 @@ class Account(Resource):
             response = response.result()
         response.raise_for_status()
 
+    def session(self, **kwargs):
+        """Get current user's authentication and authorization status."""
+        return self.get(self._reset_path('_session'), **kwargs)
+
+    def login(self, username, password, **kwargs):
+        """Authenticate the connection via cookie."""
+        # set headers, body explicitly
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded"
+        }
+        data = "name=%s&password=%s" % (username, password)
+        return self.post(self._reset_path('_session'), headers=headers,
+                         data=data, **kwargs)
+
+    def logout(self, **kwargs):
+        """De-authenticate the connection's cookie."""
+        return self.delete(self._reset_path('_session'), **kwargs)
+
     def all_dbs(self, **kwargs):
         """List all databases."""
         return self.get('_all_dbs', **kwargs)

--- a/cloudant/resource.py
+++ b/cloudant/resource.py
@@ -104,23 +104,6 @@ class Resource(object):
                 **opts)
         return future
 
-    def session(self, **kwargs):
-        """Get current user's authentication and authorization status."""
-        return self.get(self._reset_path('_session'), **kwargs)
-
-    def login(self, username, password, **kwargs):
-        """Authenticate the connection via cookie."""
-        # set headers, body explicitly
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded"
-        }
-        data = "name=%s&password=%s" % (username, password)
-        return self.post(self._reset_path('_session'), headers=headers, data=data, **kwargs)
-
-    def logout(self, **kwargs):
-        """De-authenticate the connection's cookie."""
-        return self.delete(self._reset_path('_session'), **kwargs)
-
     def head(self, path='', **kwargs):
         """
         Make a HEAD request against the object's URI joined

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -220,6 +220,10 @@ class DocumentTest(ResourceTest):
     def testAttachment(self):
         self.doc.attachment('file')
 
+    def testNoLoginLogout(self):
+        assert not hasattr(self.doc, 'login')
+        assert not hasattr(self.doc, 'logout')
+
     def tearDown(self):
         assert self.db.delete().status_code == 200
 


### PR DESCRIPTION
It's a bit awkward to have the code:

  db = cloudant.Database(url)
  doc = db.document(docid)
  doc.login('username', 'password')

Since these methods are not related to document nor database resources.
Account as holder of server root endpoint method is more suitable place
for them.
