### PR TITLE
Add documentation to connect to a CouchDB instance

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,13 @@ with CouchDB or Cloudant instances. Check it out:
     print response.json()
     # {'ok': True}
 
+Connect to a CouchDB instance:
+
+.. code:: python
+
+    # in this case, http://localhost:5984
+    account = cloudant.Account(uri="http://localhost:5984")
+
 HTTP requests return
 `Response <http://www.python-requests.org/en/latest/api/#requests.Response>`__
 objects, right from

--- a/cloudant/account.py
+++ b/cloudant/account.py
@@ -32,6 +32,11 @@ class Account(Resource):
 
         account = cloudant.Account()
         account._session.auth = (username, password)
+
+	Connect to a CouchDB instance at a given uri, here "localhost:5984"
+    (default).
+
+        account = cloudant.Account(uri="http://localhost:5984")
     """
 
     def __init__(self, uri="http://localhost:5984", **kwargs):

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,13 @@ print response.json()
 # {'ok': True}
 ```
 
+Connect to a CouchDB instance:
+
+```python
+# in this case, http://localhost:5984
+account = cloudant.Account(uri="http://localhost:5984")
+```
+
 HTTP requests return [Response][responses] objects, right from [Requests][requests].
 
 Cloudant-Python can also make asynchronous requests by passing `async=True` to an object's constructor, like so:


### PR DESCRIPTION
There's no obvious documentation how to connect to a simple CouchDB instance.  This adds a few lines to the relevant files to show how this is done.  

The goal is to show that this works just as well with non-Cloudant CouchDB instances.
