### PR TITLE
accept final slash in declaring a DB's baseurl

### DIFF
--- a/cloudant/resource.py
+++ b/cloudant/resource.py
@@ -71,7 +71,7 @@ class Resource(object):
             if urlparse.urlparse(path).scheme:
                 return path
             else:
-                return '/'.join([self.uri, path])
+                return urlparse.urljoin(self.uri, path)
         else:
             return self.uri
 


### PR DESCRIPTION
Before the patch, if the URL for the database ends in a slash:

```
from cloudant import Account, Database, Document
account = Account("http://localhost:5984/")
response = account.login(USERNAME, PASSWORD)
account.all_dbs().json()
```

Then the `account.all_dbs()` request is made to the `http://localhost:5984//_all_dbs` URI (note double slash after the port number, with result:
``
{u'couchdb': u'Welcome',
 u'vendor': {u'name': u'The Apache Software Foundation'},
 u'version': u'46cb6a4'}

```

After the patch, both using a baseurl with a final slash or without makes `account.all_dbs()` request to the correct `http://localhost:5984/_all_dbs` URI, with the resulting good behaviour:

```

from cloudant import Account, Database, Document
account = Account("http://localhost:5984/")
response = account.login(USERNAME, PASSWORD)
account.all_dbs().json()
# [u'_replicator', u'_users', u'hello', u'test']

```
```
