### PR TITLE
Fixed ability to use database.all_docs() method when using API key auth

### DIFF
--- a/cloudant/database.py
+++ b/cloudant/database.py
@@ -70,7 +70,8 @@ class Database(Resource):
             for doc in db.all_docs():
                 print doc
         """
-        return Index(self._make_url('_all_docs'), session=self._session, **kwargs)
+        opts = dict(self.opts, **kwargs)
+        return Index(self._make_url('_all_docs'), session=self._session, **opts)
 
     def __iter__(self):
         """Formats `Database.all_docs` for use as an iterator."""


### PR DESCRIPTION
Since .all_docs() previously did not pass self.opts in kwargs, using this method when using API key authorization resulted in an authorization error. There is undoubtedly a better, more universal way to fix this problem (as for instance _make_request() does in the base Resource class for all standard HTTP verb requests), but for the moment this works, and is consistent with the treatment in database.document().