### PR TITLE
Deprecates the 0.5.x branch of the cloudant python library.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,33 @@
 Cloudant-Python
 ===============
 
+This Version is Deprecated
+--------------------------
+
+As of 13 October 2015, this development branch is deprecated in favor of `the new 
+development branch starting at version 2.0.0a1 <https://github.com/cloudant/python-cloudant>`_. 
+
+**The new version will introduce breaking changes. No attempt was made to follow the 
+API in 0.5.10.**
+
+This is the final version of this branch -- 0.5.10. 
+
+Please use the new library for your new projects and begin to migrate your old projects that have 
+used versions 0.5.10 and prior. 
+
+We will keep 0.5.10 as the latest stable version on PyPI until at least early 2016, at which time 
+we plan to switch over completely to 2.0.0. 
+
+Alpha and Beta versions starting with 2.0.0a1 will be uploaded to PyPI. The latest alpha 
+or beta release may be installed by 
+
+.. code-block:: python
+
+    pip install --pre cloudant
+
+Note that our new development branch is still in alpha. As such, we cannot make any guarantees, though 
+we will try, of course, not to introduce new API that will later be removed.
+
 |Build Status| |Coverage Status| |PyPi version| |PyPi downloads|
 
 An effortless Cloudant / CouchDB interface for Python 2.7 and 3.2+.

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ This is the final version of this branch -- 0.5.10.
 Please use the new library for your new projects and begin to migrate your old projects that have 
 used versions 0.5.10 and prior. 
 
-We will keep 0.5.10 as the latest stable version on PyPI until at least early 2016, at which time 
+We will keep 0.5.10 as the latest stable version on PyPI until early 2016, at which time 
 we plan to switch over completely to 2.0.0. 
 
 Alpha and Beta versions starting with 2.0.0a1 will be uploaded to PyPI. The latest alpha 

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ or beta release may be installed by
 
     pip install --pre cloudant
 
-Note that our new development branch is still in alpha. As such, we cannot make any guarantees, though 
+Note that our new development branch is still pre 2.0.0. As such, we cannot make any guarantees, though 
 we will try, of course, not to introduce new API that will later be removed.
 
 |Build Status| |Coverage Status| |PyPi version| |PyPi downloads|

--- a/cloudant/__init__.py
+++ b/cloudant/__init__.py
@@ -7,13 +7,18 @@ from .attachment import Attachment
 from .index import Index
 
 import warnings
-message = """You are using version 0.5.10 of this library,
-             which is now deprecated. It will be replaced 
-             with version 2.0.0 in early 2016. This will 
-             introduce breaking changes. Please upgrade as
-             soon as possible. Find out more at 
-             https://github.com/cloudant/python-cloudant
-          """
+message = """
+*********************************************
+`cloudant` Deprecation Warning
+
+You are using version 0.5.10 of this library,
+which is now deprecated. It will be replaced 
+with version 2.0.0 in early 2016. This will 
+introduce breaking changes. Please upgrade as
+soon as possible. Find out more at 
+https://github.com/cloudant/python-cloudant
+*********************************************
+"""
 
 #we don't use DeprecationWarning because that message is ignored by default
 warnings.warn(message) 

--- a/cloudant/__init__.py
+++ b/cloudant/__init__.py
@@ -5,3 +5,15 @@ from .document import Document
 from .design import Design
 from .attachment import Attachment
 from .index import Index
+
+import warnings
+message = """You are using version 0.5.10 of this library,
+             which is now deprecated. It will be replaced 
+             with version 2.0.0 in early 2016. This will 
+             introduce breaking changes. Please upgrade as
+             soon as possible. Find out more at 
+             https://github.com/cloudant/python-cloudant
+          """
+
+#we don't use DeprecationWarning because that message is ignored by default
+warnings.warn(message) 

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,11 @@
 [requests]: http://www.python-requests.org/en/latest/
 [responses]: http://www.python-requests.org/en/latest/api/#requests.Response
 
-An effortless Cloudant / CouchDB interface for Python.
+## This Library is Deprecated
+
+As of 13 October 2015, this library is deprecated in favor of [a completely rewritten Python library for 
+interfacing with Cloudant and CouchDB servers](https://github.com/cloudant/python-cloudant). 
+
 
 ## Install
 

--- a/readme.md
+++ b/readme.md
@@ -9,10 +9,29 @@
 [requests]: http://www.python-requests.org/en/latest/
 [responses]: http://www.python-requests.org/en/latest/api/#requests.Response
 
-## This Library is Deprecated
+## This Version is Deprecated
 
-As of 13 October 2015, this library is deprecated in favor of [a completely rewritten Python library for 
-interfacing with Cloudant and CouchDB servers](https://github.com/cloudant/python-cloudant). 
+As of 13 October 2015, this development branch is deprecated in favor of [the new 
+development branch starting at version 2.0.0a1](https://github.com/cloudant/python-cloudant). 
+
+**The new version will introduce breaking changes. No attempt was made to follow the 
+API in 0.5.10.**
+
+This is the final version of this branch -- 0.5.10. 
+
+Please use the new library for your new projects and begin to migrate your old projects that have 
+used versions 0.5.10 and prior. 
+
+We will keep 0.5.10 as the latest stable version on PyPI until early 2016, at which time 
+we plan to switch over completely to 2.0.0. 
+
+Alpha and Beta versions starting with 2.0.0a1 will be uploaded to PyPI. The latest alpha 
+or beta release may be installed by 
+
+    pip install --pre cloudant
+
+Note that our new development branch is still pre 2.0.0. As such, we cannot make any guarantees, though 
+we will try, of course, not to introduce new API that will later be removed.
 
 
 ## Install

--- a/readme.md
+++ b/readme.md
@@ -11,26 +11,27 @@
 
 ## This Version is Deprecated
 
-As of 13 October 2015, this development branch is deprecated in favor of [the new 
-development branch starting at version 2.0.0a1](https://github.com/cloudant/python-cloudant). 
+As of 13 October 2015, this development repository is deprecated in favor of [the new 
+repository and development branch starting at version 2.0.0a1](https://github.com/cloudant/python-cloudant). 
 
 **The new version will introduce breaking changes. No attempt was made to follow the 
 API in 0.5.10.**
 
-This is the final version of this branch -- 0.5.10. 
+This is the final version of this repository and branch -- 0.5.10. 
 
 Please use the new library for your new projects and begin to migrate your old projects that have 
 used versions 0.5.10 and prior. 
 
 We will keep 0.5.10 as the latest stable version on PyPI until early 2016, at which time 
-we plan to switch over completely to 2.0.0. 
+we plan to switch over completely to 2.0.0. Also at that time, this repository will
+be taken down.
 
 Alpha and Beta versions starting with 2.0.0a1 will be uploaded to PyPI. The latest alpha 
 or beta release may be installed by 
 
     pip install --pre cloudant
 
-Note that our new development branch is still pre 2.0.0. As such, we cannot make any guarantees, though 
+Note that our new development repository is still pre 2.0.0. As such, we cannot make any guarantees, though 
 we will try, of course, not to introduce new API that will later be removed.
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,10 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(name='cloudant',
-      version='0.5.9',
+      version='0.5.10',
       description='Asynchronous Cloudant / CouchDB Interface',
-      author='Max Thayer',
-      author_email='garbados@gmail.com',
+      author='IBM',
+      author_email='alfinkel@us.ibm.com',
       url='https://github.com/cloudant-labs/cloudant',
       packages=['cloudant'],
       license='MIT',
@@ -35,6 +35,7 @@ setup(name='cloudant',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
           'Programming Language :: Python :: 3.2',
-          'Programming Language :: Python :: 3.3'
+          'Programming Language :: Python :: 3.3',
+          'Development Status :: 7 - Inactive'
       ],
       )


### PR DESCRIPTION
What:
Prepares for deprecation of 0.5.x

How:
Adds warnings to both READMEs.
Updates the version number in setup.py to 0.5.10
Adds warning to __init__.py which prints to stderr.

After this PR is merged to master, we'll push it up to PyPI. 

reviewers:
@alfinkel
@mikerhodes 